### PR TITLE
Fix start-up and shut-down UC method name mismatch

### DIFF
--- a/src/sql/create-constraints.sql
+++ b/src/sql/create-constraints.sql
@@ -807,7 +807,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var-%'
+        and asset.unit_commitment_method LIKE '3var%'
     order by
         t_high.asset,
         t_high.year,
@@ -848,7 +848,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var-%'
+        and asset.unit_commitment_method LIKE '3var%'
         and asset.investment_method in ('simple', 'none')
 
     order by
@@ -891,7 +891,7 @@ from
 where
     asset.type in ('producer', 'conversion')
     and asset.unit_commitment = true
-    and asset.unit_commitment_method LIKE '3var-%'
+    and asset.unit_commitment_method LIKE '3var%'
     and asset.investment_method = 'compact'
 order by
     t_high.asset,
@@ -936,7 +936,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var-%'
+        and asset.unit_commitment_method LIKE '3var%'
     order by
         t_high.asset,
         t_high.year,

--- a/src/sql/create-variables.sql
+++ b/src/sql/create-variables.sql
@@ -126,7 +126,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var-%'
+        and asset.unit_commitment_method LIKE '3var%'
     order by
         atr.asset,
         atr.year,
@@ -168,7 +168,7 @@ from (
     where
         asset.type in ('producer', 'conversion')
         and asset.unit_commitment = true
-        and asset.unit_commitment_method LIKE '3var-%'
+        and asset.unit_commitment_method LIKE '3var%'
     order by
         atr.asset,
         atr.year,


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaEnergyModel.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
There is no related issue.

## Bug Fix
During the code review for #1318 (adding start-up and shut-down variables), the unit commitment method `3var` was added to the schema, but the constraint and variable creation SQL required a method of the format `3var-%`. This has been fixed by changing the SQL to take methods of the form `3var%`.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaEnergyModel.jl/blob/main/docs/src/90-contributing/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
